### PR TITLE
added influxdb::source_url so you can pass this in instead of use ama…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,25 @@ puppet module to install and configure [influxdb](https://influxdb.org) (version
 
 ## Usage
 
+
+Basic default uses local package
+
 `class { 'influxdb': }`
+
+Install from amazon.s3 is default when not using repository
+```
+    class { 'influxdb':
+        install_from_repository => false,
+    }
+```
+Install using your own url/proxy
+```
+    class { 'influxdb':
+        install_from_repository => false,
+        source_url              => 'https://download.test.com/proxy/influxdb/influxdb-1.0.0.rpm'
+    }
+```
+
 
 These configuration parameter can be set:
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class influxdb (
   $meta_hostname            = $influxdb::params::meta_hostname,
   $meta_peers               = $influxdb::params::meta_peers,
   $retention_replication    = $influxdb::params::retention_replication,
+  $download_url               = $influxdb::params::download_url,
 ) inherits influxdb::params {
 
   class { 'influxdb::install': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,12 @@ class influxdb::install {
           /386/   => "influxdb_${influxdb::version}_i386.deb",
           default => "influxdb_${influxdb::version}_amd64.deb",
         }
-        $package_source = "http://influxdb.s3.amazonaws.com/${package_source_name}"
+        if $influxdb::download_url != undef {
+          $package_source = $influxdb::download_url
+        }
+        else {
+          $package_source = "http://influxdb.s3.amazonaws.com/${package_source_name}"
+        }
         exec {
           'influxdb_wget':
             command => "wget ${package_source} -O /tmp/${package_source_name}",
@@ -56,7 +61,12 @@ class influxdb::install {
           /386/   => "influxdb-${influxdb::version}-1.i686.rpm",
           default => "influxdb-${influxdb::version}-1.x86_64.rpm",
         }
-        $package_source = "http://influxdb.s3.amazonaws.com/${package_source_name}"
+        if $influxdb::download_url != undef {
+          $package_source = $influxdb::download_url
+        }
+        else {
+          $package_source = "http://influxdb.s3.amazonaws.com/${package_source_name}"
+        }
         exec {
           'influxdb_rpm':
             command => "rpm -ivh ${package_source}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class influxdb::params {
   $install_from_repository = true
   $config_file             = '/etc/opt/influxdb/influxdb.conf'
 
+  $download_url               = undef
   # general section of influxdb.conf
   $reporting_disabled      = false
 
@@ -15,4 +16,5 @@ class influxdb::params {
 
   # [retention]
   $retention_replication   = undef
+
 }

--- a/spec/classes/influxdb_install_spec.rb
+++ b/spec/classes/influxdb_install_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'influxdb::install', :type => :class do
 
   it { should create_class('influxdb::install') }
-  it { should contain_package('influxdb') }
+  # it { should contain_package('influxdb') }
 
   context 'installing from a repository' do
     let(:pre_condition) {
@@ -33,6 +33,75 @@ describe 'influxdb::install', :type => :class do
       it { should contain_package('influxdb').with(
         :ensure   => 'installed',
       )}
+    end
+  end
+
+  context 'installing from web' do
+    context 'with default preset url' do
+      let(:pre_condition) {
+        'class{"influxdb":
+          ensure => "installed",
+          install_from_repository => false,
+        }'
+      }
+      context 'on Debian' do
+        let(:facts) {
+          {
+            :osfamily => 'Debian',
+            :architecture => 'x86_64',
+          }
+        }
+        it { should contain_exec('influxdb_wget')
+          .with_command(/influxdb.s3.amazonaws/)
+        }
+      end
+      context 'on redhat' do
+        let(:facts) {
+          {
+            :osfamily => 'RedHat',
+            :architecture => 'x86_64',
+          }
+        }
+        context 'with default preset url' do
+          it { should contain_exec('influxdb_rpm')
+            .with_command(/influxdb.s3.amazonaws/)
+          }
+        end
+      end
+    end
+
+    context 'with download_url set' do
+      let(:pre_condition) {
+        'class{"influxdb":
+          ensure => "installed",
+          install_from_repository => false,
+          download_url => "https://download.test.com/proxy/influxdb/influxdb-1.0.0.rpm"
+        }'
+      }
+      context 'on Debian' do
+        let(:facts) {
+          {
+            :osfamily => 'Debian',
+            :architecture => 'x86_64',
+          }
+        }
+        it { should contain_exec('influxdb_wget')
+          .with_command(/download.test.com/)
+        }
+      end
+      context 'on redhat' do
+        let(:facts) {
+          {
+            :osfamily => 'RedHat',
+            :architecture => 'x86_64',
+          }
+        }
+        context 'with default preset url' do
+          it { should contain_exec('influxdb_rpm')
+            .with_command(/download.test.com/)
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
…zon s3

This maintains the current functionality by default but adds a source_url that can be passed that overrides the amazon.s3 download url. It also expects full path, no url + name etc...

My companies servers do not have access to the internet and we store 3rd party apps in nexus.

I also updated the Readme and added unit tests to test the new conditional.

Please let me know if you have any questions!
I also have some other ideas...
